### PR TITLE
options.htmlのクラウド版GaroonのURLサンプルを変更

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -27,7 +27,7 @@
           <div class="note sub-block">
             <p>__MSG_input_following_url_format__</p>
             <ul>
-              <li>https://{sub-domain}.cybozu.com/</li>
+              <li>https://{sub-domain}.cybozu.com/g/</li>
               <li>https://{server-address}/scripts/{install-id}/grn.exe</li>
               <li>https://{server-address}/cgi-bin/{install-id}/grn.cgi</li>
             </ul>


### PR DESCRIPTION
ドキュメントを見ると、クラウド版ガルーンは `/g/` まで含めるようです。
サンプルのURLを修正してみました。

https://cybozu.dev/ja/id/55adaebf9fa31a27768b0046/#request-url